### PR TITLE
Add explicit consistency level setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,9 @@ Reference the acceptance spec suite for details.
 
 ### Release Notes
 
+#### 5.0.1
+* Consistency level can now be explicitly configured (the default is still `QUORUM`)
+
 #### 5.0.0
 * A lot of drastic changes due to forking stale project
 * Remove support for Red Hat packages

--- a/src/main/resources/cassandraConnectionReference.conf
+++ b/src/main/resources/cassandraConnectionReference.conf
@@ -2,7 +2,7 @@ cassandra-seed-address: "127.0.0.1"
 cassandra-port: 9042
 use-ssl: false
 applied-migrations-table-name: "applied_migrations"
-consistency-level: "LOCAL_QUORUM"
+consistency-level: "QUORUM"
 
 #auth {
 #  username: cassandra-user

--- a/src/main/resources/cassandraConnectionReference.conf
+++ b/src/main/resources/cassandraConnectionReference.conf
@@ -2,6 +2,7 @@ cassandra-seed-address: "127.0.0.1"
 cassandra-port: 9042
 use-ssl: false
 applied-migrations-table-name: "applied_migrations"
+consistency-level: "LOCAL_QUORUM"
 
 #auth {
 #  username: cassandra-user

--- a/src/main/scala/com/evolutiongaming/pillar/AppliedMigrations.scala
+++ b/src/main/scala/com/evolutiongaming/pillar/AppliedMigrations.scala
@@ -2,7 +2,6 @@ package com.evolutiongaming.pillar
 
 import java.time.Instant
 
-import com.datastax.driver.core.Session
 import com.datastax.driver.core.querybuilder.QueryBuilder
 
 import scala.jdk.CollectionConverters._

--- a/src/main/scala/com/evolutiongaming/pillar/CassandraMigrator.scala
+++ b/src/main/scala/com/evolutiongaming/pillar/CassandraMigrator.scala
@@ -2,7 +2,7 @@ package com.evolutiongaming.pillar
 
 import java.time.Instant
 
-import com.datastax.driver.core.{ResultSet, Session}
+import com.datastax.driver.core.ResultSet
 
 object CassandraMigrator {
   val appliedMigrationsTableNameDefault = "applied_migrations"

--- a/src/main/scala/com/evolutiongaming/pillar/Migration.scala
+++ b/src/main/scala/com/evolutiongaming/pillar/Migration.scala
@@ -4,7 +4,7 @@ import java.time.Instant
 import java.util.Date
 
 import com.datastax.driver.core.querybuilder.QueryBuilder
-import com.datastax.driver.core.{ResultSet, Session}
+import com.datastax.driver.core.ResultSet
 
 object Migration {
   def apply(description: String, authoredAt: Instant, up: Seq[String]): Migration = {

--- a/src/main/scala/com/evolutiongaming/pillar/Migrator.scala
+++ b/src/main/scala/com/evolutiongaming/pillar/Migrator.scala
@@ -2,7 +2,7 @@ package com.evolutiongaming.pillar
 
 import java.time.Instant
 
-import com.datastax.driver.core.{ResultSet, Session}
+import com.datastax.driver.core.ResultSet
 
 object Migrator {
   def apply(registry: Registry, appliedMigrationsTableName: String): Migrator = {

--- a/src/main/scala/com/evolutiongaming/pillar/PrintStreamReporter.scala
+++ b/src/main/scala/com/evolutiongaming/pillar/PrintStreamReporter.scala
@@ -3,8 +3,6 @@ package com.evolutiongaming.pillar
 import java.io.PrintStream
 import java.time.Instant
 
-import com.datastax.driver.core.Session
-
 class PrintStreamReporter(stream: PrintStream) extends Reporter {
 
   override def migrating(session: Session, dateRestriction: Option[Instant]): Unit = {

--- a/src/main/scala/com/evolutiongaming/pillar/Reporter.scala
+++ b/src/main/scala/com/evolutiongaming/pillar/Reporter.scala
@@ -2,8 +2,6 @@ package com.evolutiongaming.pillar
 
 import java.time.Instant
 
-import com.datastax.driver.core.Session
-
 trait Reporter {
   def migrating(session: Session, dateRestriction: Option[Instant]): Unit
   def applying(migration: Migration): Unit

--- a/src/main/scala/com/evolutiongaming/pillar/ReportingMigration.scala
+++ b/src/main/scala/com/evolutiongaming/pillar/ReportingMigration.scala
@@ -2,7 +2,7 @@ package com.evolutiongaming.pillar
 
 import java.time.Instant
 
-import com.datastax.driver.core.{ResultSet, Session}
+import com.datastax.driver.core.ResultSet
 
 class ReportingMigration(reporter: Reporter, wrapped: Migration) extends Migration {
   val description: String = wrapped.description

--- a/src/main/scala/com/evolutiongaming/pillar/ReportingMigrator.scala
+++ b/src/main/scala/com/evolutiongaming/pillar/ReportingMigrator.scala
@@ -2,7 +2,7 @@ package com.evolutiongaming.pillar
 
 import java.time.Instant
 
-import com.datastax.driver.core.{ResultSet, Session}
+import com.datastax.driver.core.ResultSet
 
 class ReportingMigrator(reporter: Reporter, wrapped: Migrator, appliedMigrationsTableName: String) extends Migrator {
   override def initialize(session: Session, keyspace: String, replicationStrategy: ReplicationStrategy): ResultSet = {

--- a/src/main/scala/com/evolutiongaming/pillar/Session.scala
+++ b/src/main/scala/com/evolutiongaming/pillar/Session.scala
@@ -1,0 +1,13 @@
+package com.evolutiongaming.pillar
+
+import com.datastax.driver.core.{Cluster, ConsistencyLevel, ResultSet, SimpleStatement, Statement, Session => CassandraSession}
+
+class Session(cassandraSession: CassandraSession, consistencyLevel: ConsistencyLevel) {
+
+  def execute(query: String): ResultSet = execute(new SimpleStatement(query))
+
+  def execute(statement: Statement): ResultSet =
+    cassandraSession.execute(statement.setConsistencyLevel(consistencyLevel))
+
+  def getCluster: Cluster = cassandraSession.getCluster
+}

--- a/src/main/scala/com/evolutiongaming/pillar/cli/Command.scala
+++ b/src/main/scala/com/evolutiongaming/pillar/cli/Command.scala
@@ -1,7 +1,6 @@
 package com.evolutiongaming.pillar.cli
 
-import com.datastax.driver.core.Session
-import com.evolutiongaming.pillar.{Registry, ReplicationStrategy}
+import com.evolutiongaming.pillar.{Session, Registry, ReplicationStrategy}
 
 case class Command(action: MigratorAction, session: Session, keyspace: String, timeStampOption: Option[Long],
                    registry: Registry, replicationStrategy: ReplicationStrategy, appliedMigrationsTableName: String)

--- a/src/main/scala/com/evolutiongaming/pillar/config/ConnectionConfiguration.scala
+++ b/src/main/scala/com/evolutiongaming/pillar/config/ConnectionConfiguration.scala
@@ -1,6 +1,6 @@
 package com.evolutiongaming.pillar.config
 
-import com.datastax.driver.core.{AuthProvider, PlainTextAuthProvider}
+import com.datastax.driver.core.{AuthProvider, ConsistencyLevel, PlainTextAuthProvider}
 import com.typesafe.config.{Config, ConfigFactory, ConfigValueType}
 
 import scala.jdk.CollectionConverters._
@@ -29,6 +29,10 @@ class ConnectionConfiguration(dataStoreName: String, environment: String, appCon
 
   val sslConfig: Option[SslConfig] = SslConfig(connectionConfig.getOptionalConfig("ssl-options"))
 
+  val consistencyLevel: ConsistencyLevel = connectionConfig
+    .getOptionalString("consistency-level")
+    .map(ConsistencyLevel.valueOf)
+    .getOrElse(ConsistencyLevel.LOCAL_QUORUM)
 }
 
 class OptionalConfig(config: Config) {

--- a/src/main/scala/com/evolutiongaming/pillar/config/ConnectionConfiguration.scala
+++ b/src/main/scala/com/evolutiongaming/pillar/config/ConnectionConfiguration.scala
@@ -32,7 +32,7 @@ class ConnectionConfiguration(dataStoreName: String, environment: String, appCon
   val consistencyLevel: ConsistencyLevel = connectionConfig
     .getOptionalString("consistency-level")
     .map(ConsistencyLevel.valueOf)
-    .getOrElse(ConsistencyLevel.LOCAL_QUORUM)
+    .getOrElse(ConsistencyLevel.QUORUM)
 }
 
 class OptionalConfig(config: Config) {

--- a/src/test/scala/com/evolutiongaming/pillar/AcceptanceAssertions.scala
+++ b/src/test/scala/com/evolutiongaming/pillar/AcceptanceAssertions.scala
@@ -1,7 +1,7 @@
 package com.evolutiongaming.pillar
 
 import com.datastax.driver.core.querybuilder.QueryBuilder
-import com.datastax.driver.core.{Metadata, Session}
+import com.datastax.driver.core.Metadata
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
 

--- a/src/test/scala/com/evolutiongaming/pillar/CassandraSpec.scala
+++ b/src/test/scala/com/evolutiongaming/pillar/CassandraSpec.scala
@@ -1,6 +1,6 @@
 package com.evolutiongaming.pillar
 
-import com.datastax.driver.core.Cluster
+import com.datastax.driver.core.{Cluster, ConsistencyLevel}
 import org.cassandraunit.utils.EmbeddedCassandraServerHelper
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, Suite}
@@ -26,7 +26,12 @@ trait CassandraSpec extends ScalaFutures with BeforeAndAfterAll {
     Cluster.builder().addContactPoint("127.0.0.1").withPort(port).build()
   }
 
-  lazy val session = cluster.connect()
+  //Appropriate consistency level for embedded Cassandra instance
+  private val EmbeddedConsistencyLevel = ConsistencyLevel.LOCAL_ONE
+
+  lazy val session = new Session(cluster.connect(), EmbeddedConsistencyLevel)
+
+  protected def session(keyspace: String) = new Session(cluster.connect(keyspace), EmbeddedConsistencyLevel)
 
   protected def startEmbeddedCassandra(): Unit = try {
     //Start the Cassandra Instance

--- a/src/test/scala/com/evolutiongaming/pillar/PillarLibraryAcceptanceSpec.scala
+++ b/src/test/scala/com/evolutiongaming/pillar/PillarLibraryAcceptanceSpec.scala
@@ -156,7 +156,7 @@ class PillarLibraryAcceptanceSpec extends AnyFeatureSpec
       Given("a migration that creates a views table")
 
       When("the migrator migrates the schema")
-      migrator.migrate(cluster.connect(keyspaceName))
+      migrator.migrate(session(keyspaceName))
 
       Then("the keyspace contains the events table")
       session.execute(QueryBuilder.select().from(keyspaceName, "events")).all().size() should equal(0)
@@ -177,7 +177,7 @@ class PillarLibraryAcceptanceSpec extends AnyFeatureSpec
       Given("a migration that creates a views table")
 
       When("the migrator migrates the schema")
-      migrator.migrate(cluster.connect(keyspaceName))
+      migrator.migrate(session(keyspaceName))
 
       Then("the keyspace contains the events table")
       session.execute(QueryBuilder.select().from(keyspaceName, "events")).all().size() should equal(0)
@@ -197,7 +197,7 @@ class PillarLibraryAcceptanceSpec extends AnyFeatureSpec
       Given("a migration that creates a views table")
 
       When("the migrator migrates with a cut off date")
-      migrator.migrate(cluster.connect(keyspaceName), Some(migrations.head.authoredAt))
+      migrator.migrate(session(keyspaceName), Some(migrations.head.authoredAt))
 
       Then("the keyspace contains the events table")
       session.execute(QueryBuilder.select().from(keyspaceName, "events")).all().size() should equal(0)
@@ -211,10 +211,10 @@ class PillarLibraryAcceptanceSpec extends AnyFeatureSpec
       migrator.initialize(session, keyspaceName, simpleStrategy)
 
       Given("a set of migrations applied in the past")
-      migrator.migrate(cluster.connect(keyspaceName))
+      migrator.migrate(session(keyspaceName))
 
       When("the migrator applies migrations")
-      migrator.migrate(cluster.connect(keyspaceName))
+      migrator.migrate(session(keyspaceName))
 
       Then("the migration completes successfully")
     }
@@ -230,10 +230,10 @@ class PillarLibraryAcceptanceSpec extends AnyFeatureSpec
       migrator.initialize(session, keyspaceName, simpleStrategy)
 
       Given("a set of migrations applied in the past")
-      migrator.migrate(cluster.connect(keyspaceName))
+      migrator.migrate(session(keyspaceName))
 
       When("the migrator migrates with a cut off date")
-      migrator.migrate(cluster.connect(keyspaceName), Some(migrations.head.authoredAt))
+      migrator.migrate(session(keyspaceName), Some(migrations.head.authoredAt))
 
       Then("the migrator reverses the reversible migration")
       val thrown = intercept[InvalidQueryException] {
@@ -256,11 +256,11 @@ class PillarLibraryAcceptanceSpec extends AnyFeatureSpec
       migrator.initialize(session, keyspaceName, simpleStrategy)
 
       Given("a set of migrations applied in the past")
-      migrator.migrate(cluster.connect(keyspaceName))
+      migrator.migrate(session(keyspaceName))
 
       When("the migrator migrates with a cut off date")
       val thrown = intercept[IrreversibleMigrationException] {
-        migrator.migrate(cluster.connect(keyspaceName), Some(Instant.ofEpochMilli(0)))
+        migrator.migrate(session(keyspaceName), Some(Instant.ofEpochMilli(0)))
       }
 
       Then("the migrator reverses the reversible migrations")

--- a/src/test/scala/com/evolutiongaming/pillar/PrintStreamReporterSpec.scala
+++ b/src/test/scala/com/evolutiongaming/pillar/PrintStreamReporterSpec.scala
@@ -3,7 +3,6 @@ package com.evolutiongaming.pillar
 import java.io.{ByteArrayOutputStream, PrintStream}
 import java.time.Instant
 
-import com.datastax.driver.core.Session
 import org.mockito.MockitoSugar
 import org.scalatest._
 import org.scalatest.funspec.AnyFunSpec

--- a/src/test/scala/com/evolutiongaming/pillar/ReportingMigrationSpec.scala
+++ b/src/test/scala/com/evolutiongaming/pillar/ReportingMigrationSpec.scala
@@ -1,6 +1,5 @@
 package com.evolutiongaming.pillar
 
-import com.datastax.driver.core.Session
 import org.mockito.MockitoSugar
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers

--- a/src/test/scala/com/evolutiongaming/pillar/ReportingMigratorSpec.scala
+++ b/src/test/scala/com/evolutiongaming/pillar/ReportingMigratorSpec.scala
@@ -1,6 +1,5 @@
 package com.evolutiongaming.pillar
 
-import com.datastax.driver.core.Session
 import org.mockito.MockitoSugar
 import org.scalatest.funspec.AnyFunSpec
 

--- a/src/test/scala/com/evolutiongaming/pillar/cli/CommandExecutorSpec.scala
+++ b/src/test/scala/com/evolutiongaming/pillar/cli/CommandExecutorSpec.scala
@@ -2,7 +2,6 @@ package com.evolutiongaming.pillar.cli
 
 import java.time.Instant
 
-import com.datastax.driver.core.Session
 import com.evolutiongaming.pillar._
 import org.mockito.MockitoSugar
 import org.scalatest.BeforeAndAfter


### PR DESCRIPTION
This PR adds an explicit consistency level setting to Pillar. This comes handy when using Pillar as a library in another application, as currently is such mode Pillar implicitly falls back to whatever the default Cassandra consistency level is. And if the application does not set it, it is `LOCAL_ONE`. The explicit consistency level setting makes it impossible to end up with `LOCAL_ONE` unless desired.